### PR TITLE
feat(jkanime): implement iframe download links

### DIFF
--- a/examples/08_file_download_links.py
+++ b/examples/08_file_download_links.py
@@ -14,23 +14,25 @@ from rich.console import Console
 from rich.table import Table
 from rich import print as rprint
 
-from ani_scrapy import JKAnimeScraper
+from ani_scrapy import JKAnimeScraper, AnimeAV1Scraper
 
-BRAVE_PATH = r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
+BRAVE_PATH = (
+    r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
+)
 
 console = Console()
 
 
 async def main():
     """Run the file download links example."""
-    rprint("[bold cyan]=== Example 09: File Download Links[/bold cyan]\n")
+    rprint("[bold cyan]=== Example 08: File Download Links[/bold cyan]\n")
 
     async with JKAnimeScraper(
         headless=True,
         executable_path=BRAVE_PATH,
     ) as scraper:
-        anime_id = "gachiakuta"
-        episode_number = 24
+        anime_id = "sousou-no-frieren-2nd-season"
+        episode_number = 9
 
         rprint(
             f"[bold]Getting download links for:[/bold] {anime_id} - "
@@ -38,7 +40,8 @@ async def main():
         )
 
         rprint(
-            "[bold yellow]=== Step 1: Get Table Download Links ===" + "[/bold yellow]"
+            "[bold yellow]=== Step 1: Get Table Download Links ==="
+            + "[/bold yellow]"
         )
         start = time.perf_counter()
         table_links = await scraper.get_table_download_links(
@@ -86,25 +89,123 @@ async def main():
             start_link = time.perf_counter()
 
             try:
-                final_url = await scraper.get_file_download_link(download_info=link)
+                final_url = await scraper.get_file_download_link(
+                    download_info=link
+                )
                 elapsed_link = time.perf_counter() - start_link
 
                 if final_url:
                     url_display = (
-                        final_url[:60] + "..." if len(final_url) > 60 else final_url
+                        final_url[:60] + "..."
+                        if len(final_url) > 60
+                        else final_url
                     )
                     results_table.add_row(link.server, url_display)
                     rprint(f"  [green]✓ Got URL[/green] ({elapsed_link:.2f}s)")
                 else:
-                    results_table.add_row(link.server, "[red]Failed to resolve[/red]")
+                    results_table.add_row(
+                        link.server, "[red]Failed to resolve[/red]"
+                    )
                     rprint(
-                        "  [red]✗ Failed to resolve[/red] " + f"({elapsed_link:.2f}s)"
+                        "  [red]✗ Failed to resolve[/red] "
+                        + f"({elapsed_link:.2f}s)"
                     )
             except Exception as e:
                 rprint(f"  [red]✗ Error: {e}[/red]")
                 results_table.add_row(link.server, f"[red]Error: {e}[/red]")
 
         console.print(results_table)
+
+    rprint(
+        "\n[bold cyan]=== AnimeAV1: Iframe Download Links ===[/bold cyan]\n"
+    )
+
+    async with AnimeAV1Scraper(
+        headless=True, executable_path=BRAVE_PATH
+    ) as scraper_av1:
+        anime_id_av1 = "sousou-no-frieren-2nd-season"
+        episode_number_av1 = 9
+
+        rprint(
+            f"[bold]Getting iframe download links for:[/bold] {anime_id_av1} - "
+            + f"Episode {episode_number_av1}\n"
+        )
+
+        rprint(
+            "[bold yellow]=== Step 1: Get Iframe Download Links ===[/bold yellow]"
+        )
+        start_av1 = time.perf_counter()
+        iframe_links = await scraper_av1.get_iframe_download_links(
+            anime_id=anime_id_av1, episode_number=episode_number_av1
+        )
+        elapsed_av1 = time.perf_counter() - start_av1
+
+        if iframe_links.download_links:
+            table_av1 = Table(title="AnimeAV1 Iframe Download Links")
+            table_av1.add_column("Server", style="cyan")
+            table_av1.add_column("URL", style="magenta")
+
+            for link in iframe_links.download_links:
+                url_display = (
+                    link.url[:60] + "..."
+                    if link.url and len(link.url) > 60
+                    else link.url or "N/A"
+                )
+                table_av1.add_row(link.server, url_display)
+
+            console.print(table_av1)
+            rprint(f"[dim]Time: {elapsed_av1:.2f}s[/dim]\n")
+        else:
+            rprint("[yellow]No iframe download links found[/yellow]\n")
+            return
+
+        rprint(
+            "[bold yellow]=== Step 2: Resolve Final Download URLs from Iframe ==="
+            + "[/bold yellow]"
+        )
+        rprint(
+            "[dim]This extracts the actual file URL from the iframe download page"
+            + "[/dim]\n"
+        )
+
+        results_iframe = Table(title="AnimeAV1 Final Download URLs")
+        results_iframe.add_column("Server", style="cyan")
+        results_iframe.add_column("Final URL", style="green")
+
+        for link in iframe_links.download_links:
+            if not link.url:
+                continue
+
+            rprint(f"[bold]Resolving {link.server}...[/bold]")
+            start_link = time.perf_counter()
+
+            try:
+                final_url = await scraper_av1.get_file_download_link(
+                    download_info=link
+                )
+                elapsed_link = time.perf_counter() - start_link
+
+                if final_url:
+                    url_display = (
+                        final_url[:60] + "..."
+                        if len(final_url) > 60
+                        else final_url
+                    )
+                    results_iframe.add_row(link.server, url_display)
+                    rprint(f"  [green]✓ Got URL[/green] ({elapsed_link:.2f}s)")
+                else:
+                    results_iframe.add_row(
+                        link.server, "[red]Failed to resolve[/red]"
+                    )
+                    rprint(
+                        "  [red]✗ Failed to resolve[/red] "
+                        + f"({elapsed_link:.2f}s)"
+                    )
+            except Exception as e:
+                rprint(f"  [red]✗ Error: {e}[/red]")
+                results_iframe.add_row(link.server, f"[red]Error: {e}[/red]")
+
+        console.print(results_iframe)
 
     rprint("\n[bold cyan]=== Example Complete ===[/bold cyan]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ani-scrapy"
-version = "0.5.2"
+version = "0.6.0"
 description = "Async-first Python library for scraping anime websites. Supports some anime websites with unified interface, detailed metadata, and download links from multiple servers."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ani_scrapy/providers/jkanime/constants.py
+++ b/src/ani_scrapy/providers/jkanime/constants.py
@@ -2,7 +2,9 @@ from ani_scrapy.core.schemas import _AnimeType, _RelatedType
 
 BASE_URL = "https://jkanime.net"
 SEARCH_ENDPOINT = "buscar"
-BASE_EPISODE_IMG_URL = "https://cdn.jkdesu.com/assets/images/animes/video/image_thumb"
+BASE_EPISODE_IMG_URL = (
+    "https://cdn.jkdesu.com/assets/images/animes/video/image_thumb"
+)
 SW_DOWNLOAD_URL = "https://flaswish.com/f"
 IMPERSONATE = "chrome"
 

--- a/src/ani_scrapy/providers/jkanime/scraper.py
+++ b/src/ani_scrapy/providers/jkanime/scraper.py
@@ -54,6 +54,11 @@ class JKAnimeScraper(BaseScraper):
             "Mediafire": self._get_mediafire_file_link,
         }
 
+        self._iframe_link_getters = {
+            "Magi": self._get_magi_link,
+            "Streamwish": self._get_streamwish_link,
+        }
+
     async def _safe_click(
         self,
         element,
@@ -434,7 +439,14 @@ class JKAnimeScraper(BaseScraper):
             html, episode_number
         )
         all_download_links: list[DownloadLinkInfo] = [
-            DownloadLinkInfo(server=link["server"], url=link["url"])
+            DownloadLinkInfo(
+                server=link["server"],
+                url=(
+                    None
+                    if link["url"] and "c1.jkplayers.com" in link["url"]
+                    else link["url"]
+                ),
+            )
             for link in download_links_data
         ]
 
@@ -454,9 +466,144 @@ class JKAnimeScraper(BaseScraper):
     ) -> EpisodeDownloadInfo:
         """Get iframe download links for an episode."""
 
-        logger.warning("iframe download links not supported for JKAnime")
+        logger.info(
+            "Getting iframe download links | anime_id={anime_id} episode_number={episode_number}",
+            anime_id=anime_id,
+            episode_number=episode_number,
+        )
 
-        return EpisodeDownloadInfo(episode_number=episode_number, download_links=[])
+        browser = await self._get_browser()
+        async with await browser.new_page() as page:
+            return await self._get_iframe_download_links_internal(
+                page, anime_id, episode_number
+            )
+
+    async def _get_iframe_download_links_internal(
+        self,
+        page,
+        anime_id: str,
+        episode_number: int,
+    ) -> EpisodeDownloadInfo:
+        """Get iframe download links using page from Playwright."""
+
+        url = f"{BASE_URL}/{anime_id}/{episode_number}"
+        await page.goto(url)
+
+        await page.wait_for_selector("#collapseServers")
+
+        download_links: list[DownloadLinkInfo] = []
+
+        for server_name, link_getter in self._iframe_link_getters.items():
+            logger.debug("Looking for server | server={server}", server=server_name)
+            server_link = await page.query_selector(
+                f'#collapseServers a:has-text("{server_name}")'
+            )
+
+            if not server_link:
+                logger.warning(
+                    "Server not found in page | server={server}",
+                    server=server_name,
+                )
+                continue
+
+            await server_link.click()
+            await page.wait_for_timeout(3000)
+
+            try:
+                download_url = await link_getter(page)
+                if download_url is not None:
+                    download_links.append(
+                        DownloadLinkInfo(server=server_name, url=download_url)
+                    )
+                    logger.info(
+                        "Got iframe URL | server={server} url={url}",
+                        server=server_name,
+                        url=download_url,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to get link for server | server={server} error={error}",
+                    server=server_name,
+                    error=str(e),
+                )
+                download_links.append(DownloadLinkInfo(server=server_name, url=None))
+
+        logger.info(
+            "Iframe download links fetched | count={count}",
+            count=len(download_links),
+        )
+        return EpisodeDownloadInfo(
+            episode_number=episode_number,
+            download_links=download_links,
+        )
+
+    async def _get_magi_link(self, page) -> str | None:
+        """Get Magi server link."""
+        logger.debug("Getting Magi link")
+
+        video_box_iframe = await page.query_selector("#video_box iframe")
+        if not video_box_iframe:
+            logger.warning("Video box iframe not found")
+            return None
+
+        src = await video_box_iframe.get_attribute("src")
+        logger.debug("Video box iframe src | src={src}", src=src)
+
+        frame = page.frame(url=lambda u: "jkanime.net/jkplayer" in u)
+        if not frame:
+            logger.warning("JKPlayer frame not found")
+            return None
+
+        logger.debug("Found jkanime frame, waiting for content...")
+
+        try:
+            magi_video = await frame.wait_for_selector(
+                "video#video_html5_api", timeout=5000
+            )
+            if magi_video:
+                source = await magi_video.query_selector("source")
+                if source:
+                    download_url = await source.get_attribute("src")
+                    logger.debug("Found Magi source | src={src}", src=download_url)
+                    return download_url
+        except Exception:
+            logger.warning("Magi video not found")
+
+        return None
+
+    async def _get_streamwish_link(self, page) -> str | None:
+        """Get Streamwish server link."""
+        logger.debug("Getting Streamwish link")
+
+        video_box_iframe = await page.query_selector("#video_box iframe")
+        if not video_box_iframe:
+            logger.warning("Video box iframe not found")
+            return None
+
+        src = await video_box_iframe.get_attribute("src")
+        logger.debug("Video box iframe src | src={src}", src=src)
+
+        frame = page.frame(url=lambda u: "jkanime.net/jkplayer" in u)
+        if not frame:
+            logger.warning("JKPlayer frame not found")
+            return None
+
+        logger.debug("Found jkanime frame, waiting for content...")
+
+        try:
+            streamwish_iframe = await frame.wait_for_selector(
+                'iframe[src*="sfastwish.com"]', timeout=5000
+            )
+            if streamwish_iframe:
+                iframe_src = await streamwish_iframe.get_attribute("src")
+                video_id = iframe_src.split("/")[-1]
+                download_url = f"{SW_DOWNLOAD_URL}/{video_id}"
+                logger.debug("Found Streamwish iframe | src={src}", src=iframe_src)
+                return download_url
+        except Exception:
+            logger.warning("Streamwish iframe not found")
+
+        return None
 
     async def get_file_download_link(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "ani-scrapy"
-version = "0.5.0"
+version = "0.5.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Add get_iframe_download_links method for extracting download URLs
from iframe embedded players (Magi and Streamwish).

- Add Magi to supported servers
- Separate server logic into private methods (_get_magi_link,
  _get_streamwish_link) following AnimeFLV pattern
- Add filter in get_table_download_links to set None for
  c1.jkplayers.com URLs
- Bump version to 0.6.0
