### PR TITLE
fix(animeav1): handle escaped quotes in synopsis

### DIFF
--- a/examples/02_anime_info.py
+++ b/examples/02_anime_info.py
@@ -19,9 +19,7 @@ from rich import print as rprint
 from ani_scrapy import AnimeFLVScraper, JKAnimeScraper, AnimeAV1Scraper
 from ani_scrapy.core.schemas import AnimeInfo
 
-BRAVE_PATH = (
-    r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
-)
+BRAVE_PATH = r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
 
 console = Console()
 
@@ -43,9 +41,7 @@ def format_info(anime: AnimeInfo):
     text.append("\n\n")
 
     text.append("Genres: ", style="bold cyan")
-    text.append(
-        ", ".join(anime.genres) if anime.genres else "N/A", style="white"
-    )
+    text.append(", ".join(anime.genres) if anime.genres else "N/A", style="white")
     text.append("\n\n")
 
     text.append("Description:\n", style="bold yellow")
@@ -62,9 +58,7 @@ async def main():
     """Run the anime info example."""
     rprint("[bold cyan]=== Example 02: Get Anime Information[/bold cyan]\n")
 
-    async with AnimeFLVScraper(
-        headless=False, executable_path=BRAVE_PATH
-    ) as scraper:
+    async with AnimeFLVScraper(headless=False, executable_path=BRAVE_PATH) as scraper:
         anime_id = "gachiakuta"
 
         rprint(f"[bold]Fetching info for:[/bold] '{anime_id}'\n")
@@ -105,8 +99,7 @@ async def main():
         anime_id = "gachiakuta"
 
         rprint(
-            f"[bold]Fetching info for:[/bold] '{anime_id}' "
-            + "(using Brave browser)"
+            f"[bold]Fetching info for:[/bold] '{anime_id}' " + "(using Brave browser)"
         )
         rprint(f"[dim]Browser: {BRAVE_PATH}[/dim]\n")
 
@@ -140,7 +133,7 @@ async def main():
         rprint(f"\n[dim]Elapsed time: {elapsed:.2f}s[/dim]")
 
     async with AnimeAV1Scraper() as scraper_av1:
-        anime_id = "one-piece"
+        anime_id = "yuusha-kei-ni-shosu-choubatsu-yuusha-9004-tai-keimu-kiroku"
 
         rprint(f"\n[bold]Fetching info for:[/bold] '{anime_id}' (AnimeAV1)")
 

--- a/examples/03_download_links.py
+++ b/examples/03_download_links.py
@@ -16,9 +16,7 @@ from rich import print as rprint
 
 from ani_scrapy import AnimeFLVScraper, JKAnimeScraper, AnimeAV1Scraper
 
-BRAVE_PATH = (
-    r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
-)
+BRAVE_PATH = r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
 
 console = Console()
 
@@ -39,9 +37,7 @@ async def main():
         headless=True,
         executable_path=BRAVE_PATH,
     ) as scraper_flv:
-        rprint(
-            "[bold yellow]=== AnimeFLV Table Download Links ===[/bold yellow]"
-        )
+        rprint("[bold yellow]=== AnimeFLV Table Download Links ===[/bold yellow]")
         start_flv = time.perf_counter()
         table_links = await scraper_flv.get_table_download_links(
             anime_id=anime_id, episode_number=episode_number
@@ -62,13 +58,10 @@ async def main():
 
             console.print(table)
         else:
-            rprint(
-                "[yellow]No table download links found for AnimeFLV[/yellow]"
-            )
+            rprint("[yellow]No table download links found for AnimeFLV[/yellow]")
 
         rprint(
-            "\n[bold yellow]=== AnimeFLV Iframe Download Links "
-            + "===[/bold yellow]"
+            "\n[bold yellow]=== AnimeFLV Iframe Download Links " + "===[/bold yellow]"
         )
         iframe_links = await scraper_flv.get_iframe_download_links(
             anime_id=anime_id, episode_number=episode_number
@@ -106,9 +99,7 @@ async def main():
                         )
                         rprint(f"[cyan]{final_url}[/cyan]")
         else:
-            rprint(
-                "[yellow]No iframe download links found for AnimeFLV[/yellow]"
-            )
+            rprint("[yellow]No iframe download links found for AnimeFLV[/yellow]")
 
         elapsed_flv = time.perf_counter() - start_flv
         rprint(f"\n[dim]AnimeFLV total time: {elapsed_flv:.2f}s[/dim]")
@@ -122,9 +113,7 @@ async def main():
             + f"Episode {episode_number}\n"
         )
 
-        rprint(
-            "[bold yellow]=== JKAnime Table Download Links ===[/bold yellow]"
-        )
+        rprint("[bold yellow]=== JKAnime Table Download Links ===[/bold yellow]")
         start_jk = time.perf_counter()
         table_links = await scraper_jk.get_table_download_links(
             anime_id=anime_id, episode_number=episode_number
@@ -171,13 +160,10 @@ async def main():
                     rprint("[yellow]Could not get file download link[/yellow]")
             else:
                 rprint(
-                    "[yellow]No supported servers found for file download"
-                    + "[/yellow]"
+                    "[yellow]No supported servers found for file download" + "[/yellow]"
                 )
         else:
-            rprint(
-                "[yellow]No table download links found for JKAnime[/yellow]"
-            )
+            rprint("[yellow]No table download links found for JKAnime[/yellow]")
 
         elapsed_jk = time.perf_counter() - start_jk
         rprint(f"\n[dim]JKAnime total time: {elapsed_jk:.2f}s[/dim]")
@@ -191,9 +177,7 @@ async def main():
             + f"Episode {episode_number}\n"
         )
 
-        rprint(
-            "[bold yellow]=== AnimeAV1 Table Download Links ===[/bold yellow]"
-        )
+        rprint("[bold yellow]=== AnimeAV1 Table Download Links ===[/bold yellow]")
         start_av1 = time.perf_counter()
         table_links = await scraper_av1.get_table_download_links(
             anime_id=anime_id, episode_number=episode_number
@@ -240,17 +224,12 @@ async def main():
                     rprint("[yellow]Could not get file download link[/yellow]")
             else:
                 rprint(
-                    "[yellow]No supported servers found for file download"
-                    + "[/yellow]"
+                    "[yellow]No supported servers found for file download" + "[/yellow]"
                 )
         else:
-            rprint(
-                "[yellow]No table download links found for AnimeAV1[/yellow]"
-            )
+            rprint("[yellow]No table download links found for AnimeAV1[/yellow]")
 
-        rprint(
-            "\n[bold yellow]=== AnimeAV1 Iframe Download Links ===[/bold yellow]"
-        )
+        rprint("\n[bold yellow]=== AnimeAV1 Iframe Download Links ===[/bold yellow]")
         iframe_links = await scraper_av1.get_iframe_download_links(
             anime_id=anime_id, episode_number=episode_number
         )
@@ -295,9 +274,7 @@ async def main():
                 else:
                     rprint("[yellow]Could not get file download link[/yellow]")
         else:
-            rprint(
-                "[yellow]No iframe download links found for AnimeAV1[/yellow]"
-            )
+            rprint("[yellow]No iframe download links found for AnimeAV1[/yellow]")
 
         elapsed_av1 = time.perf_counter() - start_av1
         rprint(f"\n[dim]AnimeAV1 total time: {elapsed_av1:.2f}s[/dim]")

--- a/examples/04_browser_usage.py
+++ b/examples/04_browser_usage.py
@@ -16,9 +16,7 @@ from rich import print as rprint
 
 from ani_scrapy import JKAnimeScraper
 
-BRAVE_PATH = (
-    r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
-)
+BRAVE_PATH = r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
 
 console = Console()
 

--- a/examples/07_logging_configuration.py
+++ b/examples/07_logging_configuration.py
@@ -12,7 +12,6 @@ Options:
 """
 
 import asyncio
-from loguru import logger
 from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax

--- a/examples/08_file_download_links.py
+++ b/examples/08_file_download_links.py
@@ -16,9 +16,7 @@ from rich import print as rprint
 
 from ani_scrapy import JKAnimeScraper, AnimeAV1Scraper
 
-BRAVE_PATH = (
-    r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
-)
+BRAVE_PATH = r"C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe"
 
 console = Console()
 
@@ -40,8 +38,7 @@ async def main():
         )
 
         rprint(
-            "[bold yellow]=== Step 1: Get Table Download Links ==="
-            + "[/bold yellow]"
+            "[bold yellow]=== Step 1: Get Table Download Links ===" + "[/bold yellow]"
         )
         start = time.perf_counter()
         table_links = await scraper.get_table_download_links(
@@ -89,26 +86,19 @@ async def main():
             start_link = time.perf_counter()
 
             try:
-                final_url = await scraper.get_file_download_link(
-                    download_info=link
-                )
+                final_url = await scraper.get_file_download_link(download_info=link)
                 elapsed_link = time.perf_counter() - start_link
 
                 if final_url:
                     url_display = (
-                        final_url[:60] + "..."
-                        if len(final_url) > 60
-                        else final_url
+                        final_url[:60] + "..." if len(final_url) > 60 else final_url
                     )
                     results_table.add_row(link.server, url_display)
                     rprint(f"  [green]✓ Got URL[/green] ({elapsed_link:.2f}s)")
                 else:
-                    results_table.add_row(
-                        link.server, "[red]Failed to resolve[/red]"
-                    )
+                    results_table.add_row(link.server, "[red]Failed to resolve[/red]")
                     rprint(
-                        "  [red]✗ Failed to resolve[/red] "
-                        + f"({elapsed_link:.2f}s)"
+                        "  [red]✗ Failed to resolve[/red] " + f"({elapsed_link:.2f}s)"
                     )
             except Exception as e:
                 rprint(f"  [red]✗ Error: {e}[/red]")
@@ -116,9 +106,7 @@ async def main():
 
         console.print(results_table)
 
-    rprint(
-        "\n[bold cyan]=== AnimeAV1: Iframe Download Links ===[/bold cyan]\n"
-    )
+    rprint("\n[bold cyan]=== AnimeAV1: Iframe Download Links ===[/bold cyan]\n")
 
     async with AnimeAV1Scraper(
         headless=True, executable_path=BRAVE_PATH
@@ -131,9 +119,7 @@ async def main():
             + f"Episode {episode_number_av1}\n"
         )
 
-        rprint(
-            "[bold yellow]=== Step 1: Get Iframe Download Links ===[/bold yellow]"
-        )
+        rprint("[bold yellow]=== Step 1: Get Iframe Download Links ===[/bold yellow]")
         start_av1 = time.perf_counter()
         iframe_links = await scraper_av1.get_iframe_download_links(
             anime_id=anime_id_av1, episode_number=episode_number_av1
@@ -180,26 +166,19 @@ async def main():
             start_link = time.perf_counter()
 
             try:
-                final_url = await scraper_av1.get_file_download_link(
-                    download_info=link
-                )
+                final_url = await scraper_av1.get_file_download_link(download_info=link)
                 elapsed_link = time.perf_counter() - start_link
 
                 if final_url:
                     url_display = (
-                        final_url[:60] + "..."
-                        if len(final_url) > 60
-                        else final_url
+                        final_url[:60] + "..." if len(final_url) > 60 else final_url
                     )
                     results_iframe.add_row(link.server, url_display)
                     rprint(f"  [green]✓ Got URL[/green] ({elapsed_link:.2f}s)")
                 else:
-                    results_iframe.add_row(
-                        link.server, "[red]Failed to resolve[/red]"
-                    )
+                    results_iframe.add_row(link.server, "[red]Failed to resolve[/red]")
                     rprint(
-                        "  [red]✗ Failed to resolve[/red] "
-                        + f"({elapsed_link:.2f}s)"
+                        "  [red]✗ Failed to resolve[/red] " + f"({elapsed_link:.2f}s)"
                     )
             except Exception as e:
                 rprint(f"  [red]✗ Error: {e}[/red]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ani-scrapy"
-version = "0.6.0"
+version = "0.6.1"
 description = "Async-first Python library for scraping anime websites. Supports some anime websites with unified interface, detailed metadata, and download links from multiple servers."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -26,7 +26,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=9.0.2", "pytest-asyncio>=0.24.0"]
 examples = ["tabulate>=0.9.0", "rich>=13.0.0"]
 
 [project.scripts]
@@ -38,3 +37,6 @@ Repository = "https://github.com/ElPitagoras14/ani-scrapy"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[dependency-groups]
+dev = ["pytest>=9.0.2", "ruff>=0.15.10"]

--- a/src/ani_scrapy/providers/animeav1/parser.py
+++ b/src/ani_scrapy/providers/animeav1/parser.py
@@ -127,9 +127,7 @@ class AnimeAV1Parser:
             episodes_data = media_data.get("episodes", [])
             for ep in episodes_data:
                 ep_number = ep.get("number", 0)
-                image_preview = (
-                    f"{ANIME_COVER_URL}/covers/{media_id}/{ep_number}.jpg"
-                )
+                image_preview = f"{ANIME_COVER_URL}/covers/{media_id}/{ep_number}.jpg"
                 episodes.append(
                     EpisodeInfo(
                         number=ep_number,
@@ -228,9 +226,30 @@ class AnimeAV1Parser:
                 if slug_match:
                     result["slug"] = slug_match.group(1)
 
-        # synopsis
-        synopsis_match = re.search(r'synopsis:\s*"([^"]*)"', media_str)
-        result["synopsis"] = synopsis_match.group(1) if synopsis_match else ""
+        # synopsis - handle escaped quotes
+        synopsis = ""
+        synopsis_pos = media_str.find("synopsis:")
+        if synopsis_pos != -1:
+            search_start = synopsis_pos + 9
+            # Skip whitespace and find opening quote
+            i = search_start
+            while i < len(media_str) and media_str[i] in " \t\n":
+                i += 1
+            if i < len(media_str) and media_str[i] == '"':
+                i += 1
+                quote_start = i
+                # Find unescaped closing quote
+                while i < len(media_str):
+                    if media_str[i] == "\\":
+                        i += 2
+                    elif media_str[i] == '"':
+                        synopsis = media_str[quote_start:i]
+                        break
+                    else:
+                        i += 1
+                # Unescape \" in synopsis
+                synopsis = synopsis.replace('\\"', '"')
+        result["synopsis"] = synopsis
 
         # category
         cat_match = re.search(r'category:\s*\{[^}]*name:\s*"([^"]+)"', media_str)

--- a/src/ani_scrapy/providers/jkanime/constants.py
+++ b/src/ani_scrapy/providers/jkanime/constants.py
@@ -2,9 +2,7 @@ from ani_scrapy.core.schemas import _AnimeType, _RelatedType
 
 BASE_URL = "https://jkanime.net"
 SEARCH_ENDPOINT = "buscar"
-BASE_EPISODE_IMG_URL = (
-    "https://cdn.jkdesu.com/assets/images/animes/video/image_thumb"
-)
+BASE_EPISODE_IMG_URL = "https://cdn.jkdesu.com/assets/images/animes/video/image_thumb"
 SW_DOWNLOAD_URL = "https://flaswish.com/f"
 IMPERSONATE = "chrome"
 

--- a/tests/unit/test_core/test_http.py
+++ b/tests/unit/test_core/test_http.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from ani_scrapy.core.http import AsyncHttpAdapter, BaseHttpAdapter
+from ani_scrapy.core.http import AsyncHttpAdapter
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "ani-scrapy"
-version = "0.5.2"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -160,13 +160,15 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
 examples = [
     { name = "rich" },
     { name = "tabulate" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -177,14 +179,18 @@ requires-dist = [
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "playwright", specifier = ">=1.55.0" },
     { name = "playwright-stealth", specifier = ">=2.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "rich", specifier = ">=14.3.2" },
     { name = "rich", marker = "extra == 'examples'", specifier = ">=13.0.0" },
     { name = "tabulate", marker = "extra == 'examples'", specifier = ">=0.9.0" },
     { name = "typer", specifier = ">=0.9.0" },
 ]
-provides-extras = ["dev", "examples"]
+provides-extras = ["examples"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.15.10" },
+]
 
 [[package]]
 name = "annotated-doc"
@@ -211,15 +217,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
-]
-
-[[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -966,20 +963,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-asyncio"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
-]
-
-[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -990,6 +973,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fix parsing of AnimeAV1 synopsis when it contains escaped quotes (\")
- Add proper handling to find unescaped closing quote
- Unescape \" to " in the final synopsis string
- Bump version to 0.6.1

## Testing
- Synopsis without escaped quotes: works
- Synopsis with escaped quotes like "\"Hero\" es el peor": returns correct "Hero" es el peor
- Empty synopsis: works